### PR TITLE
sm8250: add memory hack for xiaomi devices

### DIFF
--- a/Platform/Xiaomi/sm8250/elish.dsc
+++ b/Platform/Xiaomi/sm8250/elish.dsc
@@ -13,7 +13,7 @@
 !include Platform/Qualcomm/sm8250/sm8250.dsc
 
 [BuildOptions.common]
-  GCC:*_*_AARCH64_CC_FLAGS = -DENABLE_SIMPLE_INIT -DENABLE_LINUX_SIMPLE_MASS_STORAGE
+  GCC:*_*_AARCH64_CC_FLAGS = -DMEMMAP_XIAOMI_HACKS -DENABLE_SIMPLE_INIT -DENABLE_LINUX_SIMPLE_MASS_STORAGE
 
 [PcdsFixedAtBuild.common]
   gQcomTokenSpaceGuid.PcdMipiFrameBufferWidth|1600

--- a/Silicon/Qualcomm/sm8250/Library/PlatformMemoryMapLib/PlatformMemoryMapLib.c
+++ b/Silicon/Qualcomm/sm8250/Library/PlatformMemoryMapLib/PlatformMemoryMapLib.c
@@ -2,7 +2,9 @@
 #include <Library/PlatformMemoryMapLib.h>
 
 static ARM_MEMORY_REGION_DESCRIPTOR_EX gDeviceMemoryDescriptorEx[] = {
-	{"HLOS 1",           0x80000000, 0x00700000, AddMem, SYS_MEM, SYS_MEM_CAP, Conv,   WRITE_BACK_XN},
+	/* Hypervisor seems needed for windows boot? */
+	{"Hypervisor",       0x80000000, 0x00600000, AddMem, SYS_MEM, SYS_MEM_CAP, Reserv, NS_DEVICE},
+	{"HLOS 1",           0x80600000, 0x00100000, AddMem, SYS_MEM, SYS_MEM_CAP, Conv,   WRITE_BACK_XN},
 	{"AOP",              0x80700000, 0x00160000, AddMem, MEM_RES, UNCACHEABLE, Reserv, UNCACHED_UNBUFFERED_XN},
 	{"AOP CMD DB",       0x80860000, 0x00020000, AddMem, MEM_RES, UNCACHEABLE, Reserv, UNCACHED_UNBUFFERED_XN},
 	{"XBL Log Buffer",   0x80880000, 0x00014000, AddMem, SYS_MEM, SYS_MEM_CAP, Reserv, WRITE_BACK_XN},
@@ -21,7 +23,14 @@ static ARM_MEMORY_REGION_DESCRIPTOR_EX gDeviceMemoryDescriptorEx[] = {
 	{"HLOS 5",           0x9FFD0000, 0x00027000, AddMem, SYS_MEM, SYS_MEM_CAP, Conv,   WRITE_BACK_XN},
 	{"Log Buffer",       0x9FFF7000, 0x00008000, AddMem, SYS_MEM, SYS_MEM_CAP, Reserv, WRITE_BACK_XN},
 	{"Info Blk",         0x9FFFF000, 0x00001000, AddMem, SYS_MEM, SYS_MEM_CAP, Reserv, WRITE_BACK_XN},
+#ifdef MEMMAP_XIAOMI_HACKS
 	{"HLOS 6",           0xA0000000, 0x1CC00000, AddMem, SYS_MEM, SYS_MEM_CAP, Conv,   WRITE_BACK_XN},
+#else
+	{"HLOS 6",           0xA0000000, 0x10000000, AddMem, SYS_MEM, SYS_MEM_CAP, Conv,   WRITE_BACK_XN},
+	/* Set pstore size to 0x00500000, otherwise OnePlus 8 Pro will crashdump. */
+	{"PSTORE",           0xB0000000, 0x00500000, AddMem, SYS_MEM, SYS_MEM_CAP, Reserv, WRITE_BACK_XN},
+	{"HLOS 7",           0xB0400000, 0x0C800000, AddMem, SYS_MEM, SYS_MEM_CAP, Conv,   WRITE_BACK_XN},
+#endif
 	{"DXE Heap",         0xC0000000, 0x0E000000, AddMem, SYS_MEM, SYS_MEM_CAP, Conv,   WRITE_BACK_XN},
 	{"UEFI FD",          0xCE000000, 0x02000000, AddMem, SYS_MEM, SYS_MEM_CAP, BsData, WRITE_BACK},
 


### PR DESCRIPTION
### Description

[Description of the changes you are submitting]

Add the memory map hack for xiaomi devices becacuse the uefi of xiaomi devices doesn't reserve ramoops/pstore, but it is reserved by kernel driver.

### Checklist

* [ ✓] Have you tested the change you are submitting?
* [ ✓] Is the commits history nice and clean?