### PR TITLE
sm7125: Port ACPI patching code

### DIFF
--- a/Silicon/Qualcomm/sm7125/Include/Library/RFSProtectionLib.h
+++ b/Silicon/Qualcomm/sm7125/Include/Library/RFSProtectionLib.h
@@ -1,0 +1,8 @@
+#ifndef __RFS_PROTECTION_H
+#define __RFS_PROTECTION_H
+
+EFI_STATUS
+EFIAPI
+RFSLocateAndProtectSharedArea();
+
+#endif

--- a/Silicon/Qualcomm/sm7125/Library/MsPlatformDevicesLib/MsPlatformDevicesLib.c
+++ b/Silicon/Qualcomm/sm7125/Library/MsPlatformDevicesLib/MsPlatformDevicesLib.c
@@ -18,8 +18,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PcdLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
-// #include <Library/AslUpdateLib.h>
+#include <Library/AslUpdateLib.h>
 #include <Library/MemoryMapHelperLib.h>
+#include <Library/RFSProtectionLib.h>
 
 #include <Configuration/BootDevices.h>
 
@@ -28,14 +29,153 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/EFISmem.h>
 
 VOID
+PlatformUpdateAcpiTables(VOID)
+{
+  EFI_STATUS Status;
+
+  ARM_MEMORY_REGION_DESCRIPTOR_EX MPSSEFSRegion;
+  ARM_MEMORY_REGION_DESCRIPTOR_EX ADSPEFSRegion;
+  ARM_MEMORY_REGION_DESCRIPTOR_EX TGCMRegion;
+
+  UINT32                              SOID  = 0;
+  UINT32                              SIDV  = 0;
+  UINT16                              SDFE  = 0;
+  UINT16                              SIDM  = 0;
+  UINT32                             *pSIDT = (UINT32 *)0x784180;
+  UINT32                              SIDT  = (*pSIDT & 0xFF00000) >> 20;
+  UINT32                             *pSJTG = (UINT32 *)0x784180;
+  UINT32                              SJTG  = *pSJTG & 0xFFFFF;
+  UINT32                             *pEMUL = (UINT32 *)0x1FC8004;
+  UINT32                              EMUL  = *pEMUL & 0x3;
+  UINT32                              SOSN1 = 0;
+  UINT32                              SOSN2 = 0;
+  UINT64                              SOSI  = 0;
+  UINT32                              PRP1  = 0xFFFFFFFF;
+  CHAR8                               SIDS[EFICHIPINFO_MAX_ID_LENGTH] = {0};
+  EFI_PLATFORMINFO_PLATFORM_INFO_TYPE PlatformInfo;
+  UINT32                              RMTB = 0;
+  UINT32                              RMTX = 0;
+  UINT32                              RFMB = 0;
+  UINT32                              RFMS = 0;
+  UINT32                              RFAB = 0;
+  UINT32                              RFAS = 0;
+  UINT32                              TCMA = 0;
+  UINT32                              TCML = 0;
+
+  EFI_CHIPINFO_PROTOCOL     *mBoardProtocol           = NULL;
+  EFI_SMEM_PROTOCOL         *pEfiSmemProtocol         = NULL;
+  EFI_PLATFORMINFO_PROTOCOL *pEfiPlatformInfoProtocol = NULL;
+
+  UINT32 SmemSize = 0;
+
+  //
+  // Find the ChipInfo protocol
+  //
+  Status = gBS->LocateProtocol(
+      &gEfiChipInfoProtocolGuid, NULL, (VOID *)&mBoardProtocol);
+  if (EFI_ERROR(Status)) {
+    return;
+  }
+
+  //
+  // Find the SMEM protocol
+  //
+  Status = gBS->LocateProtocol(
+      &gQcomSMEMProtocolGuid, NULL, (VOID **)&pEfiSmemProtocol);
+  if (EFI_ERROR(Status)) {
+    return;
+  }
+
+  //
+  // Find the PlatformInfo protocol
+  //
+  Status = gBS->LocateProtocol(
+      &gEfiPlatformInfoProtocolGuid, NULL, (VOID **)&pEfiPlatformInfoProtocol);
+  if (EFI_ERROR(Status)) {
+    return;
+  }
+
+  mBoardProtocol->GetChipId(mBoardProtocol, &SOID);
+  mBoardProtocol->GetChipVersion(mBoardProtocol, &SIDV);
+  mBoardProtocol->GetChipFamily(mBoardProtocol, (EFIChipInfoFamilyType *)&SDFE);
+  mBoardProtocol->GetModemSupport(mBoardProtocol, (EFIChipInfoModemType *)&SIDM);
+  mBoardProtocol->GetSerialNumber(mBoardProtocol, (EFIChipInfoSerialNumType *)&SOSN1);
+  mBoardProtocol->GetQFPROMChipId(mBoardProtocol, (EFIChipInfoQFPROMChipIdType *)&SOSN2);
+  mBoardProtocol->GetChipIdString(mBoardProtocol, SIDS, EFICHIPINFO_MAX_ID_LENGTH);
+
+  pEfiSmemProtocol->GetFunc(137, &SmemSize, (VOID **)&SOSI);
+
+  pEfiPlatformInfoProtocol->GetPlatformInfo(pEfiPlatformInfoProtocol, &PlatformInfo);
+
+  UINT16 SVMJ = (UINT16)((SIDV >> 16) & 0xFFFF);
+  UINT16 SVMI = (UINT16)(SIDV & 0xFFFF);
+  UINT64 SOSN = ((UINT64)SOSN2 << 32) | SOSN1;
+  UINT32 PLST = PlatformInfo.subtype;
+
+  if (!EFI_ERROR(LocateMemoryMapAreaByName("MPSS_EFS", &MPSSEFSRegion))) {
+    RMTB = MPSSEFSRegion.Address;
+    RMTX = MPSSEFSRegion.Length;
+  }
+
+  if (!EFI_ERROR(LocateMemoryMapAreaByName("ADSP_EFS", &ADSPEFSRegion))) {
+    RFMB = ADSPEFSRegion.Address + ADSPEFSRegion.Length / 2;
+    RFMS = ADSPEFSRegion.Length / 2;
+    RFAB = ADSPEFSRegion.Address;
+    RFAS = ADSPEFSRegion.Length / 2;
+  }
+
+  if (!EFI_ERROR(LocateMemoryMapAreaByName("TGCM", &TGCMRegion))) {
+    TCMA = TGCMRegion.Address;
+    TCML = TGCMRegion.Length;
+  } else {
+    TCMA = 0xDEADBEEF;
+    TCML = 0xBEEFDEAD;
+  }
+
+  DEBUG((EFI_D_WARN, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"));
+  DEBUG((EFI_D_WARN, "Chip Id: %d\n", SOID));
+  DEBUG((EFI_D_WARN, "Chip Family Id: %d\n", SDFE));
+  DEBUG((EFI_D_WARN, "Chip Major Version: %d\n", SVMJ));
+  DEBUG((EFI_D_WARN, "Chip Minor Version: %d\n", SVMI));
+  DEBUG((EFI_D_WARN, "Chip Modem Support: 0x%x\n", SIDM));
+  DEBUG((EFI_D_WARN, "Chip Serial Number: 0x%x\n", SOSN));
+  DEBUG((EFI_D_WARN, "Chip Name: %a\n", SIDS));
+  DEBUG((EFI_D_WARN, "Chip Info Address: 0x%x\n", SOSI));
+  DEBUG((EFI_D_WARN, "Platform Subtype: %d\n", PLST));
+
+  // gBS->Stall(10 * 1000 * 1000);
+  UpdateNameAslCode(SIGNATURE_32('S', 'O', 'I', 'D'), &SOID, 4);
+  UpdateNameAslCode(SIGNATURE_32('S', 'I', 'D', 'V'), &SIDV, 4);
+  UpdateNameAslCode(SIGNATURE_32('S', 'V', 'M', 'J'), &SVMJ, 2);
+  UpdateNameAslCode(SIGNATURE_32('S', 'V', 'M', 'I'), &SVMI, 2);
+  UpdateNameAslCode(SIGNATURE_32('S', 'D', 'F', 'E'), &SDFE, 2);
+  UpdateNameAslCode(SIGNATURE_32('S', 'I', 'D', 'M'), &SIDM, 2);
+  UpdateNameAslCode(SIGNATURE_32('S', 'I', 'D', 'T'), &SIDT, 4);
+  UpdateNameAslCode(SIGNATURE_32('S', 'J', 'T', 'G'), &SJTG, 4);
+  UpdateNameAslCode(SIGNATURE_32('S', 'O', 'S', 'N'), &SOSN, 8);
+  UpdateNameAslCode(SIGNATURE_32('P', 'L', 'S', 'T'), &PLST, 4);
+  UpdateNameAslCode(SIGNATURE_32('E', 'M', 'U', 'L'), &EMUL, 4);
+  UpdateNameAslCode(SIGNATURE_32('R', 'M', 'T', 'B'), &RMTB, 4);
+  UpdateNameAslCode(SIGNATURE_32('R', 'M', 'T', 'X'), &RMTX, 4);
+  UpdateNameAslCode(SIGNATURE_32('R', 'F', 'M', 'B'), &RFMB, 4);
+  UpdateNameAslCode(SIGNATURE_32('R', 'F', 'M', 'S'), &RFMS, 4);
+  UpdateNameAslCode(SIGNATURE_32('R', 'F', 'A', 'B'), &RFAB, 4);
+  UpdateNameAslCode(SIGNATURE_32('R', 'F', 'A', 'S'), &RFAS, 4);
+  UpdateNameAslCode(SIGNATURE_32('T', 'C', 'M', 'A'), &TCMA, 4);
+  UpdateNameAslCode(SIGNATURE_32('T', 'C', 'M', 'L'), &TCML, 4);
+  UpdateNameAslCode(SIGNATURE_32('S', 'O', 'S', 'I'), &SOSI, 8);
+  UpdateNameAslCode(SIGNATURE_32('P', 'R', 'P', '1'), &PRP1, 4);
+  UpdateNameAslCode(SIGNATURE_32('S', 'I', 'D', 'S'), &SIDS, EFICHIPINFO_MAX_ID_LENGTH);
+}
+
+VOID
 EFIAPI
 PlatformSetup()
 {
   // Allow MPSS and HLOS to access the allocated RFS Shared Memory Region
   // Normally this would be done by a driver in Linux
-  // TODO: Move to a better place!
-  // RFSLocateAndProtectSharedArea();
+  RFSLocateAndProtectSharedArea();
 
   // Patch ACPI Tables
-  // PlatformUpdateAcpiTables();
+  PlatformUpdateAcpiTables();
 }

--- a/Silicon/Qualcomm/sm7125/Library/MsPlatformDevicesLib/MsPlatformDevicesLib.inf
+++ b/Silicon/Qualcomm/sm7125/Library/MsPlatformDevicesLib/MsPlatformDevicesLib.inf
@@ -37,8 +37,8 @@
   IoLib
   UefiBootServicesTableLib
   UefiLib
-  # AslUpdateLib
-  # RFSProtectionLib
+  AslUpdateLib
+  RFSProtectionLib
   MemoryMapHelperLib
 
 [Protocols]

--- a/Silicon/Qualcomm/sm7125/Library/RFSProtectionLib/RFSProtectionLib.c
+++ b/Silicon/Qualcomm/sm7125/Library/RFSProtectionLib/RFSProtectionLib.c
@@ -1,0 +1,144 @@
+
+#include <Uefi.h>
+
+#include <Library/DebugLib.h>
+#include <Library/DevicePathLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/MsPlatformDevicesLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/MemoryMapHelperLib.h>
+
+#include <Library/BaseMemoryLib.h>
+#include <Protocol/EFIScm.h>
+#include <Protocol/scm_sip_interface.h>
+
+#include <Library/RFSProtectionLib.h>
+
+#define MAX_DESTINATION_VMS 3
+
+EFI_STATUS
+EFIAPI
+RFSProtectSharedArea(UINT64 efsBaseAddr, UINT64 efsBaseSize)
+{
+  EFI_STATUS             Status                       = EFI_SUCCESS;
+  hyp_memprot_ipa_info_t ipaInfo;
+  QCOM_SCM_PROTOCOL     *pQcomScmProtocol             = NULL;
+  UINT32                 dataSize                     = 0;
+  UINT32                 sourceVM                     = AC_VM_HLOS;
+  UINT64                 results[SCM_MAX_NUM_RESULTS] = {0};
+  VOID                  *data                         = NULL;
+
+  // Allow both HLOS (Windows) and MSS (Modem Subsystem) to access the shared memory region
+  // This is needed otherwise the Modem Subsystem will CRASH when attempting to read data
+  hyp_memprot_dstVM_perm_info_t dstVM_perm_info[MAX_DESTINATION_VMS] = {
+    {
+      AC_VM_HLOS, 
+      (VM_PERM_R | VM_PERM_W), 
+      (UINT64)NULL, 
+      0
+    },
+    {
+      AC_VM_MSS_MSA, 
+      (VM_PERM_R | VM_PERM_W), 
+      (UINT64)NULL, 
+      0
+    },
+    {
+      AC_VM_MSS_NAV, 
+      (VM_PERM_R | VM_PERM_W), 
+      (UINT64)NULL, 
+      0
+    }
+  };
+
+  UINT64                 parameterArray[SCM_MAX_NUM_PARAMETERS] = {0};
+  hyp_memprot_assign_t  *assign = (hyp_memprot_assign_t *)parameterArray;
+
+  Status = gBS->LocateProtocol(
+      &gQcomScmProtocolGuid, 
+      NULL, 
+      (VOID **)&pQcomScmProtocol
+  );
+
+  if (EFI_ERROR(Status)) {
+    return Status;
+  }
+
+  // Fill in the address details
+  ipaInfo.IPAaddr = efsBaseAddr;
+  ipaInfo.IPAsize = efsBaseSize;
+
+  dataSize = sizeof(hyp_memprot_ipa_info_t) + 
+                  sizeof(sourceVM) +
+                  (MAX_DESTINATION_VMS * sizeof(hyp_memprot_dstVM_perm_info_t)) + 
+                  4;
+
+  data = AllocateZeroPool(dataSize);
+  if (data == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  assign->IPAinfolist = (UINT64)data;
+
+  CopyMem(
+    (VOID *)assign->IPAinfolist, 
+    &ipaInfo, 
+    sizeof(hyp_memprot_ipa_info_t)
+  );
+
+  assign->IPAinfolistsize = sizeof(hyp_memprot_ipa_info_t);
+
+  assign->sourceVMlist =
+      (UINT64)data + 
+      sizeof(hyp_memprot_ipa_info_t);
+
+  CopyMem(
+    (VOID *)assign->sourceVMlist, 
+    &sourceVM, 
+    sizeof(sourceVM)
+  );
+
+  assign->srcVMlistsize = sizeof(sourceVM);
+
+  assign->destVMlist =
+      (UINT64)data + 
+      sizeof(hyp_memprot_ipa_info_t) + 
+      sizeof(sourceVM) + 
+      4;
+
+  CopyMem(
+      (VOID *)assign->destVMlist, 
+      dstVM_perm_info,
+      MAX_DESTINATION_VMS * sizeof(hyp_memprot_dstVM_perm_info_t)
+  );
+
+  assign->destVMlistsize = MAX_DESTINATION_VMS * sizeof(hyp_memprot_dstVM_perm_info_t);
+  assign->spare          = 0;
+
+  // Send the hypervisor call
+  Status = pQcomScmProtocol->ScmSipSysCall(
+      pQcomScmProtocol, 
+      HYP_MEM_PROTECT_ASSIGN, 
+      HYP_MEM_PROTECT_ASSIGN_PARAM_ID,
+      parameterArray, 
+      results
+  );
+
+  return Status;
+}
+
+EFI_STATUS
+EFIAPI
+RFSLocateAndProtectSharedArea()
+{
+  ARM_MEMORY_REGION_DESCRIPTOR_EX MpssEfs;
+
+  if (!EFI_ERROR(LocateMemoryMapAreaByName("MPSS_EFS", &MpssEfs))) {
+      return RFSProtectSharedArea(MpssEfs.Address, MpssEfs.Length);
+  }
+
+  return EFI_NOT_FOUND;
+}

--- a/Silicon/Qualcomm/sm7125/Library/RFSProtectionLib/RFSProtectionLib.inf
+++ b/Silicon/Qualcomm/sm7125/Library/RFSProtectionLib/RFSProtectionLib.inf
@@ -1,0 +1,35 @@
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = RFSProtectionLib
+  FILE_GUID                      = 2FDF4E63-5AD5-4385-A729-868019B45A92
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RFSProtectionLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  RFSProtectionLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  ArmPkg/ArmPkg.dec
+  Platform/RenegadePkg/RenegadePkg.dec
+  Silicon/Qualcomm/QcomPkg/QcomPkg.dec
+  Silicon/Qualcomm/sm7125/sm7125.dec
+
+[LibraryClasses]
+  ArmLib
+  DebugLib
+  MemoryAllocationLib
+  DevicePathLib
+  UefiBootServicesTableLib
+  MemoryMapHelperLib
+
+[Protocols]
+  gEfiGraphicsOutputProtocolGuid
+  gEfiSimpleTextInProtocolGuid
+  gQcomScmProtocolGuid


### PR DESCRIPTION
Signed-off-by: Molly Sophia <mollysophia379@gmail.com>

### Description

This adds the ACPI patching code ported from SurfaceDuoPkg to the sm7125 platform.
This compiles for miatoll, but I don't have any sm7125 devices so this needs to be tested.

### Checklist

* [ ] Have you tested the change you are submitting?
* [x] Is the commits history nice and clean?