### PR TITLE
Enabled framebuffer delay through device.dsc

### DIFF
--- a/Silicon/Qualcomm/QcomPkg/Library/FrameBufferSerialPortLib/FrameBufferSerialPortLib.c
+++ b/Silicon/Qualcomm/QcomPkg/Library/FrameBufferSerialPortLib/FrameBufferSerialPortLib.c
@@ -10,6 +10,8 @@
 #include <Resources/font5x12.h>
 
 #include "Library/FrameBufferSerialPortLib.h"
+#include <Library/TimerLib.h>
+
 
 FBCON_POSITION m_Position;
 FBCON_POSITION m_MaxPosition;
@@ -20,6 +22,7 @@ UINTN gWidth = FixedPcdGet32(PcdMipiFrameBufferWidth);
 // Reserve half screen for output
 UINTN gHeight = FixedPcdGet32(PcdMipiFrameBufferHeight);
 UINTN gBpp    = FixedPcdGet32(PcdMipiFrameBufferPixelBpp);
+UINTN delay = FixedPcdGet32(PcdMipiFrameBufferDelay);
 
 // Module-used internal routine
 void FbConPutCharWithFactor(char c, int type, unsigned scale_factor);
@@ -142,6 +145,7 @@ paint:
   return;
 
 newline:
+  MicroSecondDelay( delay ); 
   m_Position.y += scale_factor;
   m_Position.x = 0;
   if (m_Position.y >= m_MaxPosition.y - scale_factor) {

--- a/Silicon/Qualcomm/QcomPkg/Library/FrameBufferSerialPortLib/FrameBufferSerialPortLib.inf
+++ b/Silicon/Qualcomm/QcomPkg/Library/FrameBufferSerialPortLib/FrameBufferSerialPortLib.inf
@@ -28,9 +28,11 @@
   HobLib
   CompilerIntrinsicsLib
   CacheMaintenanceLib
+  TimerLib
 
 [Pcd]
   gQcomTokenSpaceGuid.PcdMipiFrameBufferAddress
   gQcomTokenSpaceGuid.PcdMipiFrameBufferWidth
   gQcomTokenSpaceGuid.PcdMipiFrameBufferHeight
   gQcomTokenSpaceGuid.PcdMipiFrameBufferPixelBpp
+  gQcomTokenSpaceGuid.PcdMipiFrameBufferDelay

--- a/Silicon/Qualcomm/QcomPkg/QcomPkg.dec
+++ b/Silicon/Qualcomm/QcomPkg/QcomPkg.dec
@@ -51,6 +51,8 @@
   gQcomTokenSpaceGuid.PcdMipiFrameBufferPixelBpp|32|UINT32|0x0000a403
   gQcomTokenSpaceGuid.PcdMipiFrameBufferVisibleWidth|1080|UINT32|0x0000a404
   gQcomTokenSpaceGuid.PcdMipiFrameBufferVisibleHeight|2160|UINT32|0x0000a405
+  gQcomTokenSpaceGuid.PcdMipiFrameBufferDelay|1|UINT32|0x0000a406
+																 
   # Touch Screen
   gQcomTokenSpaceGuid.PcdTouchCtlrAddress|0|UINT16|0x0000a501
   gQcomTokenSpaceGuid.PcdTouchCtlrResetPin|0|UINT32|0x0000a502


### PR DESCRIPTION
### Description

Slow down framebuffer by adding gQcomTokenSpaceGuid.PcdMipiFrameBufferDelay under [PcdsFixedAtBuild.common] section on <device>.dsc. Time is in microseconds, so 1,000,000 us = 1 s.
This is optional and for debugging purposes.

E.g

[PcdsFixedAtBuild.common]
gQcomTokenSpaceGuid.PcdMipiFrameBufferDelay|1000000

### Checklist

* [X] Have you tested the change you are submitting?
* [X] Is the commits history nice and clean?